### PR TITLE
Fix missing service of type "IReCaptchaValidatorFactory"

### DIFF
--- a/src/ReCaptchaExtension.php
+++ b/src/ReCaptchaExtension.php
@@ -36,6 +36,7 @@ final class ReCaptchaExtension extends CompilerExtension
         $builder = $this->getContainerBuilder();
 
         $builder->addDefinition($this->prefix('validator'))
+            ->setImplement(IReCaptchaValidatorFactory::class)
             ->setClass(ReCaptchaValidator::class, [$config['secretKey']]);
     }
 


### PR DESCRIPTION
fixes #7

Please consider updating 1.5.x with php <5.6 syntax `->setImplement('Minetro\Forms\reCAPTCHA\IReCaptchaValidatorFactory')`