### PR TITLE
Update dependencies such that it works with PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
   - hhvm-nightly
 
@@ -26,6 +27,10 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAG=--prefer-lowest
     - php: 7.1
+      env: COMPOSER_FLAG=--prefer-stable
+    - php: 7.2
+      env: COMPOSER_FLAG=--prefer-lowest
+    - php: 7.2
       env: COMPOSER_FLAG=--prefer-stable
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">= 5.6",
     "nette/di": "~2.4.0",
     "nette/forms": "~2.4.0",
-    "nette/utils": "~2.4.0"
+    "nette/utils": "~2.5.0"
   },
   "require-dev": {
     "ninjify/qa": "^0.3.3",


### PR DESCRIPTION
nette/utils at v2.4 stills contains Nette\Object which makes this repo impossible to use with PHP 7.2