### PR TITLE
Composer.json: Nette Utils should be ^3.0 for future compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=7.2",
     "nette/di": "~3.0.0",
     "nette/forms": "~3.0.0",
-    "nette/utils": "~3.0.0|~3.1.0"
+    "nette/utils": "^3.0"
   },
   "require-dev": {
     "ninjify/nunjuck": "^0.4.0",

--- a/tests/cases/DI/ReCaptchaExtension.phpt
+++ b/tests/cases/DI/ReCaptchaExtension.phpt
@@ -44,5 +44,5 @@ test(function () {
 				],
 			]);
 		}, 'SC2' . time());
-	}, InvalidConfigurationException::class, 'The mandatory option \'captcha › secretKey\' is missing.');
+	}, InvalidConfigurationException::class, 'The mandatory item \'captcha › secretKey\' is missing.');
 });


### PR DESCRIPTION
I can not update my dependencies, but I think Nette Utils dependency should be `^3.0` for future compatibility.

<img width="1115" alt="Snímek obrazovky 2020-12-29 v 21 47 07" src="https://user-images.githubusercontent.com/4738758/103313139-668eac80-4a1f-11eb-87dd-552abb0667da.png">

Thanks!