### PR TITLE
Allow nette/forms v3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=7.2",
     "contributte/di": "^0.5.1",
-    "nette/forms": "~3.0.0",
+    "nette/forms": "^3.0.0",
     "nette/utils": "^3.0.0"
   },
   "require-dev": {

--- a/src/Forms/ReCaptchaField.php
+++ b/src/Forms/ReCaptchaField.php
@@ -63,11 +63,11 @@ class ReCaptchaField extends TextInput
 			return;
 		}
 
+		$this->configured = true;
 		$message = $this->message ?? 'Are you a bot?';
 		$this->addRule(function ($code): bool {
 			return $this->verify() === true;
 		}, $message);
-		$this->configured = true;
 	}
 
 	public function verify(): bool


### PR DESCRIPTION
Relaxes constraint for `nette/forms` to `^3.0`.

The change in `ReCaptchaField` had to be made because `TextInput::addRule()` calls `$this->getRules()` now, resulting in infinite loop with previous code.

Fixes #48, closes #47