### PR TITLE
Allow nette/utils 4.0, add PHP 8.1 and 8.2 tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -141,16 +141,13 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "7.2", "7.3", "7.4" ]
+        php-version: [ "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
         operating-system: [ "ubuntu-latest" ]
         composer-args: [ "" ]
         include:
           - php-version: "7.2"
             operating-system: "ubuntu-latest"
             composer-args: "--prefer-lowest"
-          - php-version: "8.0"
-            operating-system: "ubuntu-latest"
-            composer-args: ""
       fail-fast: false
 
     continue-on-error: "${{ matrix.php-version == '8.0' }}"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php": ">=7.2",
     "contributte/di": "^0.5.1",
     "nette/forms": "^3.0.0",
-    "nette/utils": "^3.0.0"
+    "nette/utils": "^3.0.0 || ^4.0"
   },
   "require-dev": {
     "ninjify/nunjuck": "^0.4",


### PR DESCRIPTION
Allows both nette/utils ^3.0 and ^4.0 as dependency and adds newer PHP versions to CI tests.