### PR TITLE
Set minimal score for validation

### DIFF
--- a/src/DI/ReCaptchaExtension.php
+++ b/src/DI/ReCaptchaExtension.php
@@ -18,6 +18,7 @@ final class ReCaptchaExtension extends CompilerExtension
 		return Expect::structure([
 			'siteKey' => Expect::string()->required(),
 			'secretKey' => Expect::string()->required(),
+			'minimalScore' => Expect::anyOf(Expect::float()->min(0)->max(1), Expect::int()->min(0)->max(1))->default(0),
 		]);
 	}
 
@@ -30,7 +31,7 @@ final class ReCaptchaExtension extends CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		$builder->addDefinition($this->prefix('provider'))
-			->setFactory(ReCaptchaProvider::class, [$config['siteKey'], $config['secretKey']]);
+			->setFactory(ReCaptchaProvider::class, [$config['siteKey'], $config['secretKey'], $config['minimalScore']]);
 	}
 
 	/**

--- a/src/Exceptions/InvalidScoreException.php
+++ b/src/Exceptions/InvalidScoreException.php
@@ -1,8 +1,0 @@
-<?php declare(strict_types = 1);
-
-namespace Contributte\ReCaptcha\Exceptions;
-
-class InvalidScoreException extends \Exception
-{
-
-}

--- a/src/Exceptions/InvalidScoreException.php
+++ b/src/Exceptions/InvalidScoreException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\ReCaptcha\Exceptions;
+
+class InvalidScoreException extends \Exception
+{
+
+}

--- a/src/Forms/InvisibleReCaptchaField.php
+++ b/src/Forms/InvisibleReCaptchaField.php
@@ -50,7 +50,7 @@ class InvisibleReCaptchaField extends HiddenField
 	public function setMinimalScore(float $score): self
 	{
 		if ($score < 0 || $score > 1) {
-			throw new InvalidScoreException('Minimal score expects to be in range 0..1 (1.0 is very likely a good interaction, 0.0 is very likely a bot).');
+			throw new \LogicException('Minimal score expects to be in range 0..1 (1.0 is very likely a good interaction, 0.0 is very likely a bot).');
 		}
 
 		$this->provider->setMinimalScore($score);

--- a/src/Forms/InvisibleReCaptchaField.php
+++ b/src/Forms/InvisibleReCaptchaField.php
@@ -2,6 +2,7 @@
 
 namespace Contributte\ReCaptcha\Forms;
 
+use Contributte\ReCaptcha\Exceptions\InvalidScoreException;
 use Contributte\ReCaptcha\ReCaptchaProvider;
 use Nette\Forms\Controls\HiddenField;
 use Nette\Forms\Form;
@@ -42,6 +43,17 @@ class InvisibleReCaptchaField extends HiddenField
 	public function setMessage(string $message): self
 	{
 		$this->message = $message;
+
+		return $this;
+	}
+
+	public function setMinimalScore(float $score): self
+	{
+		if ($score < 0 || $score > 1) {
+			throw new InvalidScoreException('Minimal score expects to be in range 0..1 (1.0 is very likely a good interaction, 0.0 is very likely a bot).');
+		}
+
+		$this->provider->setMinimalScore($score);
 
 		return $this;
 	}


### PR DESCRIPTION
For better spam filtering, you can use the score returned by Google. The score is in range 0..1 (1.0 is very likely a good interaction, 0.0 is very likely a bot).

**How to use it?**

Global settings for all forms in config.neon

```
recaptcha:
	secretKey: <secretKey>
	siteKey: <siteKey>
	minimalScore: 0.5
```

Or you can define it for each form separately.
```
$form->addInvisibleReCaptcha('recaptcha')
	->setMinimalScore(0.6);
```

Or you can have the score set globally and then set it differently for some forms.
The score set in the form has a higher priority.