### PR TITLE
Allow siteKey and secretKey parameters to be dynamic

### DIFF
--- a/src/DI/ReCaptchaExtension.php
+++ b/src/DI/ReCaptchaExtension.php
@@ -16,8 +16,8 @@ final class ReCaptchaExtension extends CompilerExtension
 	public function getConfigSchema(): Schema
 	{
 		return Expect::structure([
-			'siteKey' => Expect::string()->required(),
-			'secretKey' => Expect::string()->required(),
+			'siteKey' => Expect::string()->required()->dynamic(),
+			'secretKey' => Expect::string()->required()->dynamic(),
 			'minimalScore' => Expect::anyOf(Expect::float()->min(0)->max(1), Expect::int()->min(0)->max(1))->default(0),
 		]);
 	}


### PR DESCRIPTION
DI parameters siteKey and secretKey should be allowed to be dynamic so we'll be able to pass values from getenv() and so on.