### PR TITLE
Fix qa

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": ">=8.1",
     "nette/di": "^3.1.8",
-    "nette/forms": "^3.1.14",
+    "nette/forms": "^3.2.2",
     "nette/utils": "^4.0.3"
   },
   "require-dev": {

--- a/src/Forms/InvisibleReCaptchaField.php
+++ b/src/Forms/InvisibleReCaptchaField.php
@@ -36,7 +36,7 @@ class InvisibleReCaptchaField extends HiddenField
 
 		$form = $this->getForm();
 		assert($form !== null);
-		$this->setValue($form->getHttpData(Form::DATA_TEXT, ReCaptchaProvider::FORM_PARAMETER));
+		$this->setValue($form->getHttpData(Form::DataText, ReCaptchaProvider::FORM_PARAMETER));
 	}
 
 	public function setMessage(string $message): self

--- a/src/Forms/ReCaptchaField.php
+++ b/src/Forms/ReCaptchaField.php
@@ -34,7 +34,7 @@ class ReCaptchaField extends TextInput
 	{
 		$form = $this->getForm();
 		assert($form !== null);
-		$this->setValue($form->getHttpData(Form::DATA_TEXT, ReCaptchaProvider::FORM_PARAMETER));
+		$this->setValue($form->getHttpData(Form::DataText, ReCaptchaProvider::FORM_PARAMETER));
 	}
 
 	public function setMessage(string $message): self

--- a/tests/Cases/Forms/InvisibleReCaptchField.phpt
+++ b/tests/Cases/Forms/InvisibleReCaptchField.phpt
@@ -7,6 +7,7 @@ use Contributte\ReCaptcha\ReCaptchaProvider;
 use Contributte\Tester\Toolkit;
 use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
+use Nette\Http\FileUpload;
 use Nette\Utils\Html;
 use Tester\Assert;
 
@@ -15,7 +16,7 @@ require __DIR__ . '/../../bootstrap.php';
 final class FormMock extends Form
 {
 
-	public function getHttpData(?int $type = null, ?string $htmlName = null): mixed
+	public function getHttpData(?int $type = null, ?string $htmlName = null): FileUpload|array|string|null
 	{
 		return $htmlName;
 	}

--- a/tests/Cases/Forms/ReCaptchField.phpt
+++ b/tests/Cases/Forms/ReCaptchField.phpt
@@ -7,6 +7,7 @@ use Contributte\ReCaptcha\ReCaptchaProvider;
 use Contributte\Tester\Toolkit;
 use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
+use Nette\Http\FileUpload;
 use Nette\Utils\Html;
 use Tester\Assert;
 
@@ -15,7 +16,7 @@ require __DIR__ . '/../../bootstrap.php';
 final class FormMock extends Form
 {
 
-	public function getHttpData(?int $type = null, ?string $htmlName = null): mixed
+	public function getHttpData(?int $type = null, ?string $htmlName = null): FileUpload|array|string|null
 	{
 		return $htmlName;
 	}


### PR DESCRIPTION
nette/forms was bumped to 3.2.2 in favor of using new constants (and 3.2-3.2.1 had bug in tests with accessing undefined submittedBy when addinhg custom component)