### PR TITLE
Add api request attempts and timeout

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -23,15 +23,32 @@ The latest version is most suitable for **Nette 2.4** and **PHP >=5.6**.
 composer require contributte/recaptcha
 ```
 
-## Configuration
+Register prepared [compiler extension](https://doc.nette.org/en/dependency-injection/nette-container) in your `config.neon` file.
 
 ```neon
 extensions:
 	recaptcha: Contributte\ReCaptcha\DI\ReCaptchaExtension
+```
 
+## Configuration
+
+### Minimal configuration
+
+```neon
 recaptcha:
 	secretKey: ***
 	siteKey: ***
+```
+
+### Advanced configuration
+
+```neon
+recaptcha:
+	secretKey: ***
+	siteKey: ***
+	minimalScore: 0.5 # 0.0-1.0 v3 recaptcha threshold, 0.0 is likely a bot, 1.0 is likely a human
+	apiRequestTimeout: 5 # api request timeout
+	apiRequestAttempts: 3 # api request attempts
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": ">=8.1",
     "nette/di": "^3.1.8",
-    "nette/forms": "^3.1.14",
+    "nette/forms": "^3.2.2",
     "nette/utils": "^4.0.3"
   },
   "require-dev": {

--- a/src/DI/ReCaptchaExtension.php
+++ b/src/DI/ReCaptchaExtension.php
@@ -18,7 +18,9 @@ final class ReCaptchaExtension extends CompilerExtension
 		return Expect::structure([
 			'siteKey' => Expect::string()->required()->dynamic(),
 			'secretKey' => Expect::string()->required()->dynamic(),
-			'minimalScore' => Expect::anyOf(Expect::float()->min(0)->max(1), Expect::int()->min(0)->max(1))->default(0),
+			'minimalScore' => Expect::anyOf(Expect::float()->min(0)->max(1), Expect::int()->min(0)->max(1))->default(0)->dynamic(),
+			'apiRequestTimeout' => Expect::int()->default(5)->dynamic(),
+			'apiRequestAttempts' => Expect::int()->default(3)->dynamic(),
 		]);
 	}
 
@@ -31,7 +33,7 @@ final class ReCaptchaExtension extends CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		$builder->addDefinition($this->prefix('provider'))
-			->setFactory(ReCaptchaProvider::class, [$config['siteKey'], $config['secretKey'], $config['minimalScore']]);
+			->setFactory(ReCaptchaProvider::class, [$config['siteKey'], $config['secretKey'], $config['minimalScore'], $config['apiRequestTimeout'], $config['apiRequestAttempts']]);
 	}
 
 	/**

--- a/src/DI/ReCaptchaExtension.php
+++ b/src/DI/ReCaptchaExtension.php
@@ -18,7 +18,7 @@ final class ReCaptchaExtension extends CompilerExtension
 		return Expect::structure([
 			'siteKey' => Expect::string()->required()->dynamic(),
 			'secretKey' => Expect::string()->required()->dynamic(),
-			'minimalScore' => Expect::anyOf(Expect::float()->min(0)->max(1), Expect::int()->min(0)->max(1))->default(0)->dynamic(),
+			'minimalScore' => Expect::anyOf(Expect::float()->min(0)->max(1), Expect::int()->min(0)->max(1))->default(0.5)->dynamic(),
 			'apiRequestTimeout' => Expect::int()->default(5)->dynamic(),
 			'apiRequestAttempts' => Expect::int()->default(3)->dynamic(),
 		]);

--- a/src/Forms/InvisibleReCaptchaField.php
+++ b/src/Forms/InvisibleReCaptchaField.php
@@ -36,7 +36,7 @@ class InvisibleReCaptchaField extends HiddenField
 
 		$form = $this->getForm();
 		assert($form !== null);
-		$this->setValue($form->getHttpData(Form::DATA_TEXT, ReCaptchaProvider::FORM_PARAMETER));
+		$this->setValue($form->getHttpData(Form::DataText, ReCaptchaProvider::FORM_PARAMETER));
 	}
 
 	public function setMessage(string $message): self

--- a/src/Forms/ReCaptchaField.php
+++ b/src/Forms/ReCaptchaField.php
@@ -34,7 +34,7 @@ class ReCaptchaField extends TextInput
 	{
 		$form = $this->getForm();
 		assert($form !== null);
-		$this->setValue($form->getHttpData(Form::DATA_TEXT, ReCaptchaProvider::FORM_PARAMETER));
+		$this->setValue($form->getHttpData(Form::DataText, ReCaptchaProvider::FORM_PARAMETER));
 	}
 
 	public function setMessage(string $message): self

--- a/tests/Cases/Forms/InvisibleReCaptchField.phpt
+++ b/tests/Cases/Forms/InvisibleReCaptchField.phpt
@@ -7,6 +7,7 @@ use Contributte\ReCaptcha\ReCaptchaProvider;
 use Contributte\Tester\Toolkit;
 use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
+use Nette\Http\FileUpload;
 use Nette\Utils\Html;
 use Tester\Assert;
 
@@ -15,7 +16,7 @@ require __DIR__ . '/../../bootstrap.php';
 final class FormMock extends Form
 {
 
-	public function getHttpData(?int $type = null, ?string $htmlName = null): mixed
+	public function getHttpData(?int $type = null, ?string $htmlName = null): FileUpload|array|string|null
 	{
 		return $htmlName;
 	}

--- a/tests/Cases/Forms/ReCaptchField.phpt
+++ b/tests/Cases/Forms/ReCaptchField.phpt
@@ -7,6 +7,7 @@ use Contributte\ReCaptcha\ReCaptchaProvider;
 use Contributte\Tester\Toolkit;
 use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
+use Nette\Http\FileUpload;
 use Nette\Utils\Html;
 use Tester\Assert;
 
@@ -15,7 +16,7 @@ require __DIR__ . '/../../bootstrap.php';
 final class FormMock extends Form
 {
 
-	public function getHttpData(?int $type = null, ?string $htmlName = null): mixed
+	public function getHttpData(?int $type = null, ?string $htmlName = null): FileUpload|array|string|null
 	{
 		return $htmlName;
 	}


### PR DESCRIPTION
I have added api request timeout (default 5s) and retries (default 3), because I had one failure (after ~10 000 requests).

I also changed default minimalScore from 0.0 to 0.5, because 0.0 seems to make no sense, but maybe I overlooked something.. 0.0 would mean that every bot passes. Recaptcha v2 does not return score, so it passes on !isset($answer['score']) and score 0.5 is not checked, v3 is then checking minimal score of 0.5, which may be a BC break, but previous implementation would do nothing by default.