### PR TITLE
Resolve #55

### DIFF
--- a/src/Forms/InvisibleReCaptchaField.php
+++ b/src/Forms/InvisibleReCaptchaField.php
@@ -17,6 +17,9 @@ class InvisibleReCaptchaField extends HiddenField
 
 	private ?string $message = null;
 
+	/** @var string[] */
+	private array $errors = [];
+
 	public function __construct(ReCaptchaProvider $provider, ?string $message = null)
 	{
 		parent::__construct();
@@ -74,6 +77,29 @@ class InvisibleReCaptchaField extends HiddenField
 	public function verify(): bool
 	{
 		return $this->provider->validateControl($this) === true;
+	}
+
+	public function addError(string|\Stringable $message, bool $translate = true): void
+	{
+		$this->errors[] = $message instanceof \Stringable ? (string) $message : $message;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getErrors(): array
+	{
+		return $this->errors;
+	}
+
+	public function hasErrors(): bool
+	{
+		return count($this->errors) > 0;
+	}
+
+	public function cleanErrors(): void
+	{
+		$this->errors = [];
 	}
 
 	public function getControl(?string $caption = null): Html

--- a/tests/Cases/Forms/FieldErrorsAccessibilityTest.phpt
+++ b/tests/Cases/Forms/FieldErrorsAccessibilityTest.phpt
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Forms;
+
+use Contributte\ReCaptcha\Forms\InvisibleReCaptchaField;
+use Contributte\ReCaptcha\Forms\ReCaptchaField;
+use Contributte\ReCaptcha\ReCaptchaProvider;
+use Contributte\Tester\Toolkit;
+use Mockery;
+use Nette\Utils\Json;
+use Tester\Assert;
+use Tests\Mocks\FormMock;
+
+require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../Mocks/FormMock.php';
+
+// InvisibleReCaptchaField errors
+Toolkit::test(function (): void {
+	$provider = Mockery::mock(ReCaptchaProvider::class, ['key', 'secret'])
+		->shouldAllowMockingProtectedMethods()
+		->makePartial();
+
+	$provider->shouldReceive('makeRequest')
+		->andReturn(Json::encode(['success' => false]));
+
+	$form = new FormMock('test');
+	$field = new InvisibleReCaptchaField($provider, 'Error message');
+	$form->addComponent($field, 'recaptcha');
+
+	$field->loadHttpData();
+	$field->validate();
+
+	Assert::true($field->hasErrors());
+	Assert::contains('Error message', $field->getErrors());
+});
+
+// ReCaptchaField errors
+Toolkit::test(function (): void {
+	$provider = Mockery::mock(ReCaptchaProvider::class, ['key', 'secret'])
+		->shouldAllowMockingProtectedMethods()
+		->makePartial();
+
+	$provider->shouldReceive('makeRequest')
+		->andReturn(Json::encode(['success' => false]));
+
+	$form = new FormMock('test');
+	$field = new ReCaptchaField($provider, 'Captcha', 'Error message');
+	$form->addComponent($field, 'recaptcha');
+
+	$field->loadHttpData();
+	$field->validate();
+
+	Assert::true($field->hasErrors());
+	Assert::contains('Error message', $field->getErrors());
+});
+
+// No errors on success
+Toolkit::test(function (): void {
+	$provider = Mockery::mock(ReCaptchaProvider::class, ['key', 'secret'])
+		->shouldAllowMockingProtectedMethods()
+		->makePartial();
+
+	$provider->shouldReceive('makeRequest')
+		->andReturn(Json::encode(['success' => true]));
+
+	$form = new FormMock('test');
+	$field = new InvisibleReCaptchaField($provider);
+	$form->addComponent($field, 'recaptcha');
+
+	$field->loadHttpData();
+	$field->validate();
+
+	Assert::false($field->hasErrors());
+	Assert::equal([], $field->getErrors());
+});
+
+Mockery::close();

--- a/tests/Mocks/FormMock.php
+++ b/tests/Mocks/FormMock.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Mocks;
+
+use Contributte\ReCaptcha\ReCaptchaProvider;
+use Nette\Forms\Form;
+use Nette\Http\FileUpload;
+
+final class FormMock extends Form
+{
+
+	private string $recaptchaResponse;
+
+	public function __construct(string $recaptchaResponse = '')
+	{
+		parent::__construct('form');
+		$this->recaptchaResponse = $recaptchaResponse;
+	}
+
+	public function getHttpData(?int $type = null, ?string $htmlName = null): FileUpload|array|string|null
+	{
+		if ($htmlName === ReCaptchaProvider::FORM_PARAMETER) {
+			return $this->recaptchaResponse;
+		}
+
+		return $htmlName;
+	}
+
+	public function isAnchored(): bool
+	{
+		return true;
+	}
+
+}


### PR DESCRIPTION
Override error handling methods in InvisibleReCaptchaField since Nette's HiddenField doesn't support field-level errors by design.

Fixes #55