### PR TITLE
Fix default-branch codesniffer pipeline

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Contributte" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<!-- Rulesets -->
-	<rule ref="./vendor/contributte/qa/ruleset-8.0.xml"/>
+	<rule ref="./vendor/contributte/qa/ruleset-8.2.xml"/>
 
 	<!-- Rules -->
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">

--- a/tests/Cases/DI/ReCaptchaExtension.phpt
+++ b/tests/Cases/DI/ReCaptchaExtension.phpt
@@ -3,7 +3,6 @@
 namespace Tests\Cases\DI;
 
 use Contributte\ReCaptcha\DI\ReCaptchaExtension;
-use Contributte\ReCaptcha\Http\HttpClient;
 use Contributte\ReCaptcha\ReCaptchaProvider;
 use Contributte\Tester\Environment;
 use Contributte\Tester\Toolkit;


### PR DESCRIPTION
## Summary
- switch PHPCS base ruleset from removed `ruleset-8.0.xml` to existing `ruleset-8.2.xml` from `contributte/qa:^0.4`
- remove one unused import in `ReCaptchaExtension.phpt` so the stricter ruleset passes cleanly

## Context
- default-branch scheduled `Codesniffer` run failed because `ruleset-8.0.xml` no longer exists:
  - https://github.com/contributte/reCAPTCHA/actions/runs/21818379618/job/61760526947

## Verification
- `composer install --no-interaction --no-progress --prefer-dist`
- `make cs`
- `make qa`
- `make tests`