### PR TITLE
Expose full Google reCAPTCHA response data via ReCaptchaResponse::get…

### DIFF
--- a/src/ReCaptchaProvider.php
+++ b/src/ReCaptchaProvider.php
@@ -10,6 +10,7 @@ use Nette\SmartObject;
 /**
  * @method onValidateControl(ReCaptchaProvider $provider, BaseControl $control)
  * @method onValidate(ReCaptchaProvider $provider, mixed $response)
+ * @phpstan-import-type ReCaptchaResponseData from ReCaptchaResponse
  */
 class ReCaptchaProvider
 {
@@ -58,14 +59,14 @@ class ReCaptchaProvider
 		}
 
 		// Decode server answer (with key assoc reserved)
-		/** @var mixed[] $answer */
+		/** @var ReCaptchaResponseData $answer */
 		$answer = json_decode($response, true);
 
 		// Return response
 		return ($answer['success'] === true && ($this->minimalScore <= 0
 				|| !isset($answer['score']) || $answer['score'] >= $this->minimalScore))
-			? new ReCaptchaResponse(true)
-			: new ReCaptchaResponse(false, $answer['error-codes'] ?? null);
+			? new ReCaptchaResponse(true, null, $answer)
+			: new ReCaptchaResponse(false, $answer['error-codes'] ?? null, $answer);
 	}
 
 	public function validateControl(BaseControl $control): bool

--- a/src/ReCaptchaResponse.php
+++ b/src/ReCaptchaResponse.php
@@ -2,6 +2,16 @@
 
 namespace Contributte\ReCaptcha;
 
+/**
+ * @phpstan-type ReCaptchaResponseData array{
+ *   success: bool,
+ *   challenge_ts?: string,
+ *   hostname?: string,
+ *   'error-codes'?: string[],
+ *   score?: float,
+ *   action?: string,
+ * }
+ */
 final class ReCaptchaResponse
 {
 
@@ -10,20 +20,27 @@ final class ReCaptchaResponse
 	public const ERROR_CODE_INVALID_INPUT_SECRET = 'invalid-input-secret';
 	public const ERROR_CODE_MISSING_INPUT_RESPONSE = 'missing-input-response';
 	public const ERROR_CODE_INVALID_INPUT_RESPONSE = 'invalid-input-response';
-	public const ERROR_CODE_UNKNOWN = 'unknow';
+	public const ERROR_CODE_BAD_REQUEST = 'bad-request';
+	public const ERROR_CODE_TIMEOUT_OR_DUPLICATE = 'timeout-or-duplicate';
+	public const ERROR_CODE_UNKNOWN = 'unknown';
 
 	private bool $success;
 
 	/** @var string[]|string|null */
-	private array|string|null $error = null;
+	private array|string|null $error;
+
+	/** @var ReCaptchaResponseData|null */
+	private ?array $data;
 
 	/**
 	 * @param string[]|string|null $error
+	 * @param ReCaptchaResponseData|null $data
 	 */
-	public function __construct(bool $success, array|string|null $error = null)
+	public function __construct(bool $success, array|string|null $error = null, ?array $data = null)
 	{
 		$this->success = $success;
 		$this->error = $error;
+		$this->data = $data;
 	}
 
 	public function isSuccess(): bool
@@ -37,6 +54,14 @@ final class ReCaptchaResponse
 	public function getError(): array|string|null
 	{
 		return $this->error;
+	}
+
+	/**
+	 * @return ?ReCaptchaResponseData
+	 */
+	public function getData(): ?array
+	{
+		return $this->data;
 	}
 
 	public function __toString(): string

--- a/tests/Cases/Forms/InvisibleReCaptchField.phpt
+++ b/tests/Cases/Forms/InvisibleReCaptchField.phpt
@@ -5,10 +5,13 @@ namespace Tests\Cases\Forms;
 use Contributte\ReCaptcha\Forms\InvisibleReCaptchaField;
 use Contributte\ReCaptcha\ReCaptchaProvider;
 use Contributte\Tester\Toolkit;
+use Mockery;
 use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
+use Nette\Forms\Rules;
 use Nette\Http\FileUpload;
 use Nette\Utils\Html;
+use Nette\Utils\Json;
 use Tester\Assert;
 
 require __DIR__ . '/../../bootstrap.php';
@@ -69,3 +72,65 @@ Toolkit::test(function (): void {
 	$field->loadHttpData();
 	Assert::equal(ReCaptchaProvider::FORM_PARAMETER, $field->getValue());
 });
+
+// getRules returns Rules and triggers configureValidation exactly once
+Toolkit::test(function (): void {
+	$field = new InvisibleReCaptchaField(new ReCaptchaProvider('key', 'secret'));
+
+	$rules = $field->getRules();
+	Assert::type(Rules::class, $rules);
+	Assert::count(1, iterator_to_array($rules));
+
+	// calling again must not add the rule a second time
+	$field->getRules();
+	Assert::count(1, iterator_to_array($rules));
+});
+
+// setMessage returns self and overrides constructor message
+Toolkit::test(function (): void {
+	$provider = Mockery::mock(ReCaptchaProvider::class, ['key', 'secret'])
+		->shouldAllowMockingProtectedMethods()
+		->makePartial();
+
+	$provider->shouldReceive('makeRequest')
+		->andReturn(Json::encode(['success' => false]));
+
+	$form = new FormMock('form');
+	$field = new InvisibleReCaptchaField($provider, 'Original message');
+	$result = $field->setMessage('Custom message');
+	$form->addComponent($field, 'recaptcha');
+
+	$field->loadHttpData();
+	$field->validate();
+
+	Assert::same($field, $result);
+	Assert::contains('Custom message', $field->getErrors());
+	Assert::notContains('Original message', $field->getErrors());
+});
+
+// setMinimalScore returns self for valid score
+Toolkit::test(function (): void {
+	$field = new InvisibleReCaptchaField(new ReCaptchaProvider('key', 'secret'));
+	$result = $field->setMinimalScore(0.5);
+	Assert::same($field, $result);
+});
+
+// setMinimalScore throws for score above 1
+Toolkit::test(function (): void {
+	$field = new InvisibleReCaptchaField(new ReCaptchaProvider('key', 'secret'));
+	Assert::exception(
+		fn () => $field->setMinimalScore(1.1),
+		\LogicException::class,
+	);
+});
+
+// setMinimalScore throws for negative score
+Toolkit::test(function (): void {
+	$field = new InvisibleReCaptchaField(new ReCaptchaProvider('key', 'secret'));
+	Assert::exception(
+		fn () => $field->setMinimalScore(-0.1),
+		\LogicException::class,
+	);
+});
+
+Mockery::close();

--- a/tests/Cases/Forms/ReCaptchField.phpt
+++ b/tests/Cases/Forms/ReCaptchField.phpt
@@ -5,10 +5,13 @@ namespace Tests\Cases\Forms;
 use Contributte\ReCaptcha\Forms\ReCaptchaField;
 use Contributte\ReCaptcha\ReCaptchaProvider;
 use Contributte\Tester\Toolkit;
+use Mockery;
 use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
+use Nette\Forms\Rules;
 use Nette\Http\FileUpload;
 use Nette\Utils\Html;
+use Nette\Utils\Json;
 use Tester\Assert;
 
 require __DIR__ . '/../../bootstrap.php';
@@ -71,3 +74,40 @@ Toolkit::test(function (): void {
 	$field->loadHttpData();
 	Assert::equal(ReCaptchaProvider::FORM_PARAMETER, $field->getValue());
 });
+
+// getRules returns Rules and triggers configureValidation exactly once
+Toolkit::test(function (): void {
+	$field = new ReCaptchaField(new ReCaptchaProvider('key', 'secret'));
+
+	$rules = $field->getRules();
+	Assert::type(Rules::class, $rules);
+	Assert::count(1, iterator_to_array($rules));
+
+	// calling again must not add the rule a second time
+	$field->getRules();
+	Assert::count(1, iterator_to_array($rules));
+});
+
+// setMessage returns self and overrides constructor message
+Toolkit::test(function (): void {
+	$provider = Mockery::mock(ReCaptchaProvider::class, ['key', 'secret'])
+		->shouldAllowMockingProtectedMethods()
+		->makePartial();
+
+	$provider->shouldReceive('makeRequest')
+		->andReturn(Json::encode(['success' => false]));
+
+	$form = new FormMock('form');
+	$field = new ReCaptchaField($provider, null, 'Original message');
+	$result = $field->setMessage('Custom message');
+	$form->addComponent($field, 'recaptcha');
+
+	$field->loadHttpData();
+	$field->validate();
+
+	Assert::same($field, $result);
+	Assert::contains('Custom message', $field->getErrors());
+	Assert::notContains('Original message', $field->getErrors());
+});
+
+Mockery::close();

--- a/tests/Cases/ReCaptchResponse.phpt
+++ b/tests/Cases/ReCaptchResponse.phpt
@@ -24,3 +24,15 @@ Toolkit::test(function (): void {
 	Assert::false($response->isSuccess());
 	Assert::equal($error, $response->getError());
 });
+
+Toolkit::test(function (): void {
+	$response = new ReCaptchaResponse(true);
+	Assert::null($response->getData());
+});
+
+Toolkit::test(function (): void {
+	$data = ['success' => true, 'score' => 0.9, 'action' => 'login', 'hostname' => 'example.com'];
+	$response = new ReCaptchaResponse(true, null, $data);
+	Assert::true($response->isSuccess());
+	Assert::equal($data, $response->getData());
+});

--- a/tests/Cases/ReCaptchaProvider.phpt
+++ b/tests/Cases/ReCaptchaProvider.phpt
@@ -10,8 +10,10 @@ use Nette\Forms\Controls\BaseControl;
 use Nette\Utils\Json;
 use Tester\Assert;
 use Tests\Mocks\DummyHttpClient;
+use Tests\Mocks\ReCaptchaProviderExposed;
 
 require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../Mocks/ReCaptchaProviderExposed.php';
 
 final class ControlMock extends BaseControl
 {
@@ -22,6 +24,7 @@ final class ControlMock extends BaseControl
 	}
 
 }
+
 
 Toolkit::test(function (): void {
 	$httpClient = new DummyHttpClient();
@@ -116,4 +119,88 @@ Toolkit::test(function (): void {
 
 	$provider->setMinimalScore(0.5);
 	Assert::true($provider->validate('test')->isSuccess());
+});
+
+Toolkit::test(function (): void {
+	$provider = Mockery::mock(ReCaptchaProvider::class)
+		->shouldAllowMockingProtectedMethods()
+		->makePartial();
+
+	$provider->shouldReceive('makeRequest')
+		->once()
+		->andReturn(Json::encode([
+			'success' => true,
+			'score' => 0.7,
+			'action' => 'submit',
+			'hostname' => 'example.com',
+			'challenge_ts' => '2024-01-01T00:00:00Z',
+		]));
+
+	$provider->setMinimalScore(0.0);
+	$response = $provider->validate('test');
+	Assert::true($response->isSuccess());
+	Assert::equal([
+		'success' => true,
+		'score' => 0.7,
+		'action' => 'submit',
+		'hostname' => 'example.com',
+		'challenge_ts' => '2024-01-01T00:00:00Z',
+	], $response->getData());
+});
+
+// makeRequest returns null when response is null
+Toolkit::test(function (): void {
+	$provider = new ReCaptchaProviderExposed('key', 'secret');
+	Assert::null($provider->makeRequest(null));
+});
+
+// makeRequest returns null when response is empty string
+Toolkit::test(function (): void {
+	$provider = new ReCaptchaProviderExposed('key', 'secret');
+	Assert::null($provider->makeRequest(''));
+});
+
+// makeRequest includes remoteip in the URL when provided
+Toolkit::test(function (): void {
+	$httpClient = new DummyHttpClient();
+	$httpClient->setResponse(Json::encode(['success' => true]));
+
+	$provider = new ReCaptchaProviderExposed('key', 'secret');
+	$provider->setHttpClient($httpClient);
+	$provider->makeRequest('token', '1.2.3.4');
+
+	$url = $httpClient->getRequestedUrls()[0];
+	Assert::contains('remoteip=1.2.3.4', $url);
+});
+
+// makeRequest omits remoteip when not provided
+Toolkit::test(function (): void {
+	$httpClient = new DummyHttpClient();
+	$httpClient->setResponse(Json::encode(['success' => true]));
+
+	$provider = new ReCaptchaProviderExposed('key', 'secret');
+	$provider->setHttpClient($httpClient);
+	$provider->makeRequest('token');
+
+	$url = $httpClient->getRequestedUrls()[0];
+	Assert::notContains('remoteip', $url);
+});
+
+// getData() is available even when validation fails due to minimal score threshold
+Toolkit::test(function (): void {
+	$provider = Mockery::mock(ReCaptchaProvider::class)
+		->shouldAllowMockingProtectedMethods()
+		->makePartial();
+
+	$provider->shouldReceive('makeRequest')
+		->once()
+		->andReturn(Json::encode([
+			'success' => true,
+			'score' => 0.7,
+		]));
+
+	$provider->setMinimalScore(0.9);
+	$response = $provider->validate('test');
+	Assert::false($response->isSuccess());
+	Assert::equal(0.7, $response->getData()['score']);
 });

--- a/tests/Mocks/ReCaptchaProviderExposed.php
+++ b/tests/Mocks/ReCaptchaProviderExposed.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Mocks;
+
+use Contributte\ReCaptcha\ReCaptchaProvider;
+
+final class ReCaptchaProviderExposed extends ReCaptchaProvider
+{
+
+	public function makeRequest(?string $response, ?string $remoteIp = null): string|null
+	{
+		return parent::makeRequest($response, $remoteIp);
+	}
+
+}


### PR DESCRIPTION
…Data()

- Add getData() method to ReCaptchaResponse returning the raw API response array
- Add ReCaptchaResponseData shaped array type covering all v2/v3 response fields
- Add missing error code constants (bad-request, timeout-or-duplicate)
- Fix missing \$answer on failure branch in ReCaptchaProvider::validate()
- Expand test coverage for getRules(), setMessage(), setMinimalScore(), makeRequest()

Closes #69