### PR TITLE
Docs: switch coverage badge to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/reCAPTCHA/actions"><img src="https://badgen.net/github/checks/contributte/reCAPTCHA/master?cache=300"></a>
-  <a href="https://coveralls.io/r/contributte/reCAPTCHA"><img src="https://badgen.net/coveralls/c/github/contributte/reCAPTCHA?cache=300"></a>
+  <a href="https://codecov.io/gh/contributte/reCAPTCHA"><img src="https://badgen.net/codecov/c/github/contributte/reCAPTCHA?cache=300"></a>
   <a href="https://packagist.org/packages/contributte/reCAPTCHA"><img src="https://badgen.net/packagist/dm/contributte/reCAPTCHA"></a>
   <a href="https://packagist.org/packages/contributte/reCAPTCHA"><img src="https://badgen.net/packagist/v/contributte/reCAPTCHA"></a>
 </p>


### PR DESCRIPTION
## Summary
- replace the README Coveralls badge with Codecov
- keep the repository badges aligned with the current coverage reporting setup

## Related
- contributte/contributte#72