### PR TITLE
Use php for coverage runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Switch the `Makefile` coverage target from `phpdbg` to `php` so this repository follows the org-wide coverage runner change tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. This keeps `reCAPTCHA` aligned with the new standard and with the shared CI workflow expectations.

## Changes

- replace `-p phpdbg` with `-p php` in both `coverage` target branches in `Makefile`

## Testing

- [x] Tests pass locally (`make tests`)
- [ ] Coverage runs locally
- [ ] CI passes

Local `make coverage` currently fails in this environment because the installed PHP does not have Xdebug or PCOV enabled and the change intentionally no longer uses PHPDBG.